### PR TITLE
Replace legacy mlayer dependencies with internal copies

### DIFF
--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,5 +1,5 @@
 """Modular benchmark package for the structured M-layer project."""
 
-from .runner import BenchmarkRunner, BenchmarkConfig
+from .runner import BenchmarkRunner, BenchmarkConfig, BenchmarkDefinition
 
-__all__ = ["BenchmarkRunner", "BenchmarkConfig"]
+__all__ = ["BenchmarkRunner", "BenchmarkConfig", "BenchmarkDefinition"]

--- a/benchmark/mixing.py
+++ b/benchmark/mixing.py
@@ -3,33 +3,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from pathlib import Path
 from typing import Any, Dict
 
 import numpy as np
 
-# ---------------------------------------------------------------------------
-# Third party / project specific imports
-# ---------------------------------------------------------------------------
-# The legacy implementation keeps the helpers inside ``MCMC`` which lives next
-# to this ``benchmark`` package.  We make the modules discoverable explicitly so
-# that the new structure can be imported without relying on side effects.
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-LEGACY_MCMC = PROJECT_ROOT / "MCMC"
-LEGACY_MCMC_NEAL = PROJECT_ROOT / "MCMC_neal"
-
-import sys
-
-for path in (LEGACY_MCMC, LEGACY_MCMC_NEAL):
-    if str(path) not in sys.path:
-        sys.path.insert(0, str(path))
-
-from mlayer2 import (  # type: ignore  # legacy module
-    create_mixing_Q,
-    create_mixing_Q_step,
-    create_mixing_Q_dir,
+from .mixing_kernels import (
+    create_mixing_q,
+    create_mixing_q_directional,
+    create_mixing_q_step,
 )
-import lib  # type: ignore  # legacy module
 
 
 class MixingMatrixBackend(str, Enum):
@@ -77,25 +59,25 @@ class MixingMatrixFactory:
         backend = request.backend
         sigma = request.sigma
         if backend is MixingMatrixBackend.MLAYER_BLOCK:
-            return create_mixing_Q(
+            return create_mixing_q(
                 request.M,
                 mtype=request.mtype,
                 sigma=sigma * 20.0,
                 L=request.L,
             )
         if backend is MixingMatrixBackend.LIB_BLOCK:
-            return lib.create_mixing_Q(
+            return create_mixing_q(
                 request.M,
                 mtype=request.mtype,
                 sigma=sigma * 20.0,
                 L=request.L,
             )
         if backend is MixingMatrixBackend.MLAYER_STEP:
-            return create_mixing_Q_step(request.M, request.index + 1)
+            return create_mixing_q_step(request.M, request.index + 1)
         if backend is MixingMatrixBackend.LIB_STEP:
-            return lib.create_mixing_Q_step(request.M, request.index + 1)
+            return create_mixing_q_step(request.M, request.index + 1)
         if backend is MixingMatrixBackend.MLAYER_DIRECTIONAL:
-            return create_mixing_Q_dir(
+            return create_mixing_q_directional(
                 request.M,
                 mtype=request.mtype,
                 sigma=sigma * 20.0,

--- a/benchmark/mixing_kernels.py
+++ b/benchmark/mixing_kernels.py
@@ -1,0 +1,164 @@
+"""Self-contained mixing matrix generators for the benchmark suite."""
+from __future__ import annotations
+
+import numpy as np
+
+Array = np.ndarray
+
+
+def _circular_distance(length: int) -> Array:
+    """Return the matrix with circular distances for indices ``0..length-1``."""
+    idx = np.arange(length, dtype=np.int64)
+    diff = np.abs(idx[:, None] - idx[None, :])
+    return np.minimum(diff, length - diff).astype(np.float64)
+
+
+def create_mixing_q(
+    M: int,
+    *,
+    mtype: str = "gauss",
+    B: int | None = None,
+    L: int | None = None,
+    sigma: float = 1.0,
+    eps: float = 1e-9,
+) -> Array:
+    """Create a strictly positive row-stochastic mixing matrix.
+
+    Parameters
+    ----------
+    M:
+        Number of layers.
+    mtype:
+        ``"gauss"`` for a circular Gaussian kernel, ``"block"`` for a Gaussian on
+        ``B`` blocks lifted to layers via ``L`` (with ``M = B * L``).
+    B, L:
+        Additional block parameters used when ``mtype == "block"``.
+    sigma:
+        Base width of the Gaussian kernel.
+    eps:
+        Added everywhere before row normalisation to ensure strict positivity.
+    """
+
+    if mtype not in {"gauss", "block"}:
+        raise ValueError("mtype must be 'gauss' or 'block'")
+
+    if mtype == "gauss":
+        dist = _circular_distance(M)
+        kernel = np.exp(-(dist ** 2) / (2.0 * sigma ** 2))
+        kernel += eps
+        return kernel / kernel.sum(axis=1, keepdims=True)
+
+    if M == 1:
+        B = L = 1
+    else:
+        if B is None and L is None:
+            raise ValueError("For mtype='block' provide either B or L.")
+        if L is None:
+            L = M // B
+        if B is None:
+            B = M // L
+        if B * L != M:
+            raise ValueError("Inconsistent block parameters: B * L must equal M.")
+
+    block_dist = _circular_distance(B)
+    block_kernel = np.exp(-(block_dist ** 2) / (2.0 * sigma ** 2))
+    block_kernel += eps
+    block_kernel /= block_kernel.sum(axis=1, keepdims=True)
+
+    kernel = np.kron(block_kernel, np.ones((L, L), dtype=np.float64))
+    kernel += eps
+    return kernel / kernel.sum(axis=1, keepdims=True)
+
+
+def _apply_periodic_band(width: int, size: int) -> Array:
+    """Return an indicator matrix with ones on band diagonals of given width."""
+    mat = np.zeros((size, size), dtype=int)
+    for offset in range(width + 1):
+        np.fill_diagonal(mat[offset:], 1)
+        np.fill_diagonal(mat[:, offset:], 1)
+
+    if width == 0:
+        return mat
+
+    for offset in range(1, width + 1):
+        for i in range(size):
+            mat[i, (i + offset) % size] = 1
+            mat[(i + offset) % size, i] = 1
+    return mat
+
+
+def create_mixing_q_step(M: int, width: int, *, eps: float = 1e-8) -> Array:
+    """Create a band matrix with periodic boundaries and normalised rows."""
+    band = _apply_periodic_band(width, M).astype(np.float64)
+    band += eps
+    return band / band.sum(axis=1, keepdims=True)
+
+
+def _signed_offsets(n: int) -> Array:
+    offsets = (np.arange(n)[None, :] - np.arange(n)[:, None]) % n
+    half = n // 2
+    offsets[offsets > half] -= n
+    return offsets.astype(np.float64)
+
+
+def create_mixing_q_directional(
+    M: int,
+    *,
+    mtype: str = "gauss",
+    B: int | None = None,
+    L: int | None = None,
+    sigma: float = 1.0,
+    shift: float = 0.0,
+    skew: float = 0.0,
+    eps: float = 1e-9,
+) -> Array:
+    """Create a directed Gaussian-like kernel with optional skew and shift."""
+
+    if mtype not in {"gauss", "block"}:
+        raise ValueError("mtype must be 'gauss' or 'block'")
+
+    def _two_sided(rel: Array, base_sigma: float, skewness: float) -> Array:
+        sign = np.sign(rel)
+        width = base_sigma * (1.0 + skewness * sign)
+        width = np.maximum(width, 0.05 * base_sigma)
+        return np.exp(-(rel ** 2) / (2.0 * width ** 2))
+
+    if mtype == "gauss":
+        delta = _signed_offsets(M)
+        rel = (delta - shift) % M
+        half = M // 2
+        rel[rel > half] -= M
+        kernel = _two_sided(rel, sigma, skew) + eps
+        return kernel / kernel.sum(axis=1, keepdims=True)
+
+    if M == 1:
+        B = L = 1
+    else:
+        if B is None and L is None:
+            raise ValueError("For mtype='block' provide either B or L.")
+        if L is None:
+            L = M // B
+        if B is None:
+            B = M // L
+        if B * L != M:
+            raise ValueError("Inconsistent block parameters: B * L must equal M.")
+
+    delta_blocks = _signed_offsets(B)
+    shift_blocks = shift / max(L, 1)
+    rel_blocks = (delta_blocks - shift_blocks) % B
+    half_blocks = B // 2
+    rel_blocks[rel_blocks > half_blocks] -= B
+
+    block_kernel = _two_sided(rel_blocks, sigma, skew) + eps
+    block_kernel /= block_kernel.sum(axis=1, keepdims=True)
+
+    kernel = np.kron(block_kernel, np.ones((L, L), dtype=np.float64))
+    kernel += eps
+    return kernel / kernel.sum(axis=1, keepdims=True)
+
+
+__all__ = [
+    "create_mixing_q",
+    "create_mixing_q_step",
+    "create_mixing_q_directional",
+]

--- a/benchmark/mlayer_core.py
+++ b/benchmark/mlayer_core.py
@@ -1,0 +1,195 @@
+"""Clean-room implementation of the permanental M-layer lifting."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.optimize import linear_sum_assignment
+
+Array = np.ndarray
+
+
+@dataclass
+class PermanentalSamplerConfig:
+    exact_threshold: int = 14
+    balance: bool = True
+
+
+def _sinkhorn_balance(matrix: Array, *, max_iter: int = 1_000, tol: float = 1e-12) -> Array:
+    q = np.array(matrix, dtype=np.float64, copy=True)
+    q[q <= 0.0] = np.finfo(float).tiny
+    r = np.ones(q.shape[0], dtype=np.float64)
+    c = np.ones(q.shape[1], dtype=np.float64)
+
+    for _ in range(max_iter):
+        rq = q * c
+        row_sums = rq.sum(axis=1)
+        row_sums[row_sums == 0.0] = 1.0
+        r_new = r / row_sums
+
+        cq = (q.T * r_new).T
+        col_sums = cq.sum(axis=0)
+        col_sums[col_sums == 0.0] = 1.0
+        c_new = c / col_sums
+
+        delta = max(np.max(np.abs(r_new - r)), np.max(np.abs(c_new - c)))
+        r, c = r_new, c_new
+        if delta < tol:
+            break
+
+    return (q.T * r).T * c
+
+
+def _permanental_sampler_exact(q: Array) -> Array:
+    M = int(q.shape[0])
+    mask_full = (1 << M) - 1
+    dp = np.zeros((M + 1, 1 << M), dtype=np.float64)
+    dp[M, 0] = 1.0
+
+    for r in range(M - 1, -1, -1):
+        for mask in range(1 << M):
+            acc = 0.0
+            m = mask
+            j = 0
+            while m:
+                if m & 1:
+                    acc += q[r, j] * dp[r + 1, mask & ~(1 << j)]
+                m >>= 1
+                j += 1
+            dp[r, mask] = acc
+
+    perm = np.empty(M, dtype=np.int64)
+    mask = mask_full
+    for r in range(M):
+        total = 0.0
+        weights = np.zeros(M, dtype=np.float64)
+        m = mask
+        j = 0
+        while m:
+            if m & 1:
+                w = q[r, j] * dp[r + 1, mask & ~(1 << j)]
+                weights[j] = w
+                total += w
+            m >>= 1
+            j += 1
+
+        if total <= 0.0:
+            available = [j for j in range(M) if (mask >> j) & 1]
+            chosen = max(available, key=lambda j: q[r, j])
+        else:
+            u = np.random.rand() * total
+            csum = 0.0
+            chosen = -1
+            for j in range(M):
+                if (mask >> j) & 1:
+                    csum += weights[j]
+                    if u <= csum:
+                        chosen = j
+                        break
+            if chosen == -1:
+                for j in range(M):
+                    if (mask >> j) & 1:
+                        chosen = j
+                        break
+
+        perm[r] = chosen
+        mask &= ~(1 << chosen)
+
+    return perm
+
+
+def _permanental_sampler_gumbel_hungarian(q: Array, eps: float = 1e-18) -> Array:
+    M = q.shape[0]
+    gumbel = -np.log(-np.log(np.random.rand(M, M) + eps) + eps)
+    scores = np.log(q + eps) + gumbel
+    _, col_ind = linear_sum_assignment(-scores)
+    return col_ind.astype(np.int64)
+
+
+def generate_permutation_permanental(
+    q: Array, *, config: PermanentalSamplerConfig | None = None
+) -> Array:
+    """Sample a permutation with probability proportional to the permanent."""
+
+    if config is None:
+        config = PermanentalSamplerConfig()
+
+    work = np.asarray(q, dtype=np.float64)
+    if config.balance:
+        work = _sinkhorn_balance(work)
+
+    if work.shape[0] <= config.exact_threshold:
+        return _permanental_sampler_exact(work)
+    return _permanental_sampler_gumbel_hungarian(work)
+
+
+def _flatten(layer: int, node: int, size: int) -> int:
+    return layer * size + node
+
+
+def mlayer(
+    couplings: Array,
+    layers: int,
+    mixing: Array,
+    *,
+    typeperm: str = "sym",
+    sampler_config: PermanentalSamplerConfig | None = None,
+) -> sp.csr_matrix:
+    """Lift a base coupling matrix to ``layers`` using permanental wiring."""
+
+    if layers == 1:
+        return sp.csr_matrix(couplings)
+
+    base = np.asarray(couplings)
+    n = base.shape[0]
+    upper = np.triu(base)
+    rows, cols = np.nonzero(upper)
+
+    sampler_config = sampler_config or PermanentalSamplerConfig()
+
+    data: list[float] = []
+    row_idx: list[int] = []
+    col_idx: list[int] = []
+
+    for i, j in zip(rows, cols):
+        weight = float(upper[i, j])
+        if weight == 0.0:
+            continue
+
+        if typeperm == "sym":
+            perm = generate_permutation_permanental(mixing, config=sampler_config)
+            for layer in range(layers):
+                target = int(perm[layer])
+                row_idx.append(_flatten(target, i, n))
+                col_idx.append(_flatten(layer, j, n))
+                data.append(weight)
+
+                row_idx.append(_flatten(layer, j, n))
+                col_idx.append(_flatten(target, i, n))
+                data.append(weight)
+        elif typeperm == "asym":
+            perm_forward = generate_permutation_permanental(mixing, config=sampler_config)
+            perm_backward = generate_permutation_permanental(mixing, config=sampler_config)
+            for layer in range(layers):
+                tgt_f = int(perm_forward[layer])
+                tgt_b = int(perm_backward[layer])
+                row_idx.append(_flatten(tgt_f, i, n))
+                col_idx.append(_flatten(layer, j, n))
+                data.append(weight)
+
+                row_idx.append(_flatten(tgt_b, j, n))
+                col_idx.append(_flatten(layer, i, n))
+                data.append(weight)
+        else:
+            raise ValueError("typeperm must be 'sym' or 'asym'")
+
+    size = n * layers
+    return sp.csr_matrix((data, (row_idx, col_idx)), shape=(size, size))
+
+
+__all__ = [
+    "PermanentalSamplerConfig",
+    "generate_permutation_permanental",
+    "mlayer",
+]

--- a/benchmark/mlayer_transform.py
+++ b/benchmark/mlayer_transform.py
@@ -2,24 +2,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Optional
+from typing import Callable
 
 import numpy as np
 import scipy.sparse as sp
 
-import sys
+from .mlayer_core import mlayer
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-LEGACY_MCMC = PROJECT_ROOT / "MCMC"
-LEGACY_MCMC_NEAL = PROJECT_ROOT / "MCMC_neal"
-
-for path in (LEGACY_MCMC, LEGACY_MCMC_NEAL):
-    if str(path) not in sys.path:
-        sys.path.insert(0, str(path))
-
-import mlayer2  # type: ignore  # legacy module
-import lib  # type: ignore  # legacy module
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+MLayerConstructor = Callable[[np.ndarray, int, np.ndarray, str], np.ndarray]
 
 
 @dataclass
@@ -30,41 +23,55 @@ class MLayerTransformRequest:
     M: int
     mixing_matrix: np.ndarray
     typeperm: str = "asym"
-    backend: str = "mlayer2"
+    backend: str = "permanental"
 
 
 class MLayerTransformer:
-    """Wraps the different legacy M-layer implementations behind one API."""
+    """Wrap the M-layer implementation behind a simple API."""
 
     def transform(self, request: MLayerTransformRequest) -> np.ndarray:
         """Return the dense coupling matrix after applying the M-layer map."""
 
         backend = request.backend.lower()
-        if backend == "mlayer2":
-            result = mlayer2.Mlayer(
-                request.J0_dense,
-                request.M,
-                request.mixing_matrix,
-                typeperm=request.typeperm,
-            )
-        elif backend == "lib":
-            result = lib.Mlayer(
-                request.J0_dense,
-                request.M,
-                permute=True,
-                GoG=True,
-                typeperm=request.typeperm,
-                C=request.mixing_matrix,
-            )
-        else:
+        if backend not in {"mlayer2", "permanental"}:
             raise ValueError(f"Unsupported M-layer backend: {request.backend}")
+
+        result = mlayer(
+            request.J0_dense,
+            request.M,
+            request.mixing_matrix,
+            typeperm=request.typeperm,
+        )
 
         if sp.issparse(result):
             return np.array(result.todense())
         return np.array(result)
 
 
+def create_mlayer_constructor(backend: str) -> MLayerConstructor:
+    """Return a callable that applies the requested M-layer transformation."""
+
+    backend_name = backend.lower()
+    if backend_name not in {"mlayer2", "permanental"}:
+        raise ValueError(f"Unsupported M-layer constructor backend: {backend}")
+
+    def _mlayer2_constructor(
+        J0_dense: np.ndarray,
+        M: int,
+        Q: np.ndarray,
+        typeperm: str = "asym",
+    ) -> np.ndarray:
+        result = mlayer(J0_dense, M, Q, typeperm=typeperm)
+        if sp.issparse(result):
+            return np.array(result.todense())
+        return np.array(result)
+
+    return _mlayer2_constructor
+
+
 __all__ = [
     "MLayerTransformer",
     "MLayerTransformRequest",
+    "MLayerConstructor",
+    "create_mlayer_constructor",
 ]


### PR DESCRIPTION
## Summary
- add clean-room implementations of the mixing matrix generators and permanental M-layer lift used by the benchmark suite
- update the benchmark mixing factory and transformer to rely on the new internal helpers instead of importing legacy modules
- default benchmark configuration to the new permanental backend while keeping the constructor interface compatible

## Testing
- python -m compileall benchmark

------
https://chatgpt.com/codex/tasks/task_e_68d45ef0439083318c8f4094c86246a9