### PR TITLE
Allow benchmark runner to be executed directly

### DIFF
--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -1,6 +1,7 @@
 """Reference benchmark driver using the modular components."""
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Sequence
@@ -8,12 +9,24 @@ from typing import Callable, Dict, Sequence
 import numpy as np
 from tqdm import tqdm
 
-from .mixing import MixingMatrixBackend, MixingMatrixFactory, MixingMatrixRequest
-from .mlayer_transform import MLayerConstructor, create_mlayer_constructor
-from .observables import ObservableEvaluator
-from .plotting import BenchmarkPlotter, PlotConfig
-from .problems import BetheProblem, IsingProblem
-from .algorithms.simulated_annealing import SimulatedAnnealingConfig, SimulatedAnnealingRunner
+if __package__ in {None, ""}:
+    # Allow running the module directly as ``python benchmark/runner.py`` by making
+    # sure the repository root (parent of ``benchmark``) is importable.
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from benchmark.mixing import (
+    MixingMatrixBackend,
+    MixingMatrixFactory,
+    MixingMatrixRequest,
+)
+from benchmark.mlayer_transform import MLayerConstructor, create_mlayer_constructor
+from benchmark.observables import ObservableEvaluator
+from benchmark.plotting import BenchmarkPlotter, PlotConfig
+from benchmark.problems import BetheProblem, IsingProblem
+from benchmark.algorithms.simulated_annealing import (
+    SimulatedAnnealingConfig,
+    SimulatedAnnealingRunner,
+)
 
 
 @dataclass
@@ -173,3 +186,14 @@ class BenchmarkRunner:
 
 
 __all__ = ["BenchmarkRunner", "BenchmarkConfig", "BenchmarkDefinition"]
+
+
+def main() -> None:
+    """Run the benchmark with the default configuration."""
+
+    runner = BenchmarkRunner(BenchmarkConfig())
+    runner.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend benchmark.runner to adjust sys.path when executed as a script
- add a simple main entry point so the module can be run directly with defaults

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d463caa3888331a8a47bf77c5b4a6d