### PR TITLE
Make shift_skew script runnable from arbitrary locations

### DIFF
--- a/benchmark/tasks/shift_skew.py
+++ b/benchmark/tasks/shift_skew.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Tuple
 
+import sys
+
 import matplotlib.pyplot as plt
 import numpy as np
+
+if __package__ is None or __package__ == "":
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
 
 from benchmark.runner import BenchmarkConfig, BenchmarkRunner
 


### PR DESCRIPTION
## Summary
- insert the repository root onto sys.path when shift_skew.py is executed directly so the benchmark package can be imported from any working directory

## Testing
- python -m compileall benchmark/tasks/shift_skew.py

------
https://chatgpt.com/codex/tasks/task_e_68d5d26bb3988331a0f0f16f68f76a0d