### PR TITLE
Add sweep script for residual analysis across layer counts

### DIFF
--- a/task/sweep_L.py
+++ b/task/sweep_L.py
@@ -1,8 +1,9 @@
 """Sweep over different layer counts and plot residual energy trends."""
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -10,9 +11,12 @@ import numpy as np
 from benchmark.runner import BenchmarkConfig, BenchmarkRunner
 
 
+DEFAULT_L_VALUES: Sequence[int] = (1, 2, 3, 4, 5)
+
+
 def sweep_layer_counts(
     *,
-    L_values: Iterable[int] = (1, 2, 3, 4, 5),
+    L_values: Iterable[int] = DEFAULT_L_VALUES,
     output_root: Path | None = None,
 ) -> None:
     """Run the benchmark for a range of ``L`` values and plot the results."""
@@ -82,9 +86,55 @@ def sweep_layer_counts(
         )
         plt.close()
 
+        summary = np.column_stack(
+            [
+                np.asarray(recorded_L, dtype=int),
+                np.asarray(best_sigmas, dtype=float),
+                np.asarray(best_residuals, dtype=float),
+                np.asarray(best_errors, dtype=float),
+            ]
+        )
+        np.savetxt(
+            output_root / "best_residual_vs_L.csv",
+            summary,
+            delimiter=",",
+            header="L,sigma_best,residual_best,ci95_residual",
+            comments="",
+        )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the benchmark sweep for several layer counts and collect "
+            "residual statistics."
+        )
+    )
+    parser.add_argument(
+        "--L",
+        "--layers",
+        dest="L_values",
+        metavar="L",
+        type=int,
+        nargs="+",
+        help=(
+            "Layer counts to evaluate. Defaults to the preset sequence "
+            f"{list(DEFAULT_L_VALUES)}."
+        ),
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=None,
+        help="Directory where results should be written.",
+    )
+    return parser.parse_args()
+
 
 def main() -> None:
-    sweep_layer_counts()
+    args = _parse_args()
+    L_values = args.L_values or DEFAULT_L_VALUES
+    sweep_layer_counts(L_values=L_values, output_root=args.output_root)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend the sweep script to expose a small CLI for choosing layer counts and output directory
- persist the best residual summary to CSV while continuing to emit the same plots as the benchmark runner

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b7529bc88331898e857fe8c08220